### PR TITLE
runtime: Update to GNOME 48

### DIFF
--- a/io.github.diegoivan.pdf_metadata_editor.json
+++ b/io.github.diegoivan.pdf_metadata_editor.json
@@ -1,7 +1,7 @@
 {
   "app-id": "io.github.diegoivan.pdf_metadata_editor",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "47",
+  "runtime-version": "48",
   "sdk": "org.gnome.Sdk",
   "command": "pdf-metadata-editor",
   "finish-args": [


### PR DESCRIPTION
New runtime brings altered dark theme and corner radii of Libadwaita 1.7