### PR TITLE
Update Paper Clip runtime to 49

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Paper Clip
+
+___Edit PDF document metadata___
+
+Edit the title, author, keywords and more details of your PDF documents
+
+---
+
+## Manual Install and Run
+
+Make sure you follow the [setup guide for your Linux distribution](https://flathub.org/en/setup) before installing
+
+```
+flatpak install flathub io.github.diegoivan.pdf_metadata_editor
+flatpak run io.github.diegoivan.pdf_metadata_editor
+```
+
+## Building
+
+```
+git clone git@github.com:yakushabb/io.github.diegoivan.pdf_metadata_editor.git
+flatpak run org.flatpak.Builder build-dir --user --ccache --force-clean --install io.github.diegoivan.pdf_metadata_editor.json
+```
+
+---
+
+**Technologies**: GNOME, GTK4, Libadwaita, Poppler, Libexempi, Vala

--- a/io.github.diegoivan.pdf_metadata_editor.json
+++ b/io.github.diegoivan.pdf_metadata_editor.json
@@ -12,9 +12,11 @@
   ],
   "cleanup": [
     "/include",
+    "/lib/girepository-1.0",
     "/lib/pkgconfig",
     "/man",
     "/share/doc",
+    "/share/gir-1.0",
     "/share/gtk-doc",
     "/share/man",
     "/share/pkgconfig",

--- a/io.github.diegoivan.pdf_metadata_editor.json
+++ b/io.github.diegoivan.pdf_metadata_editor.json
@@ -46,8 +46,8 @@
         {
           "url": "https://gitlab.freedesktop.org/poppler/poppler.git",
           "type": "git",
-          "tag": "poppler-23.01.0",
-          "commit": "4259ff0c2067d302f97d87221a442eec8e88d45c"
+          "tag": "poppler-25.12.0",
+          "commit": "45d43f4685d0596abcecd2587d4b821e8e40879b"
         }
       ]
     },
@@ -60,9 +60,10 @@
       ],
       "sources": [
         {
-          "url": "https://gitlab.freedesktop.org/libopenraw/exempi/-/archive/2.6.4/exempi-2.6.4.tar.gz",
-          "type": "archive",
-          "sha256": "7d1b0e96b848fe3fcf5f5bdb353cc82527b6629e40ed838efe9ffc9108e1b99b"
+          "url": "https://gitlab.freedesktop.org/libopenraw/exempi.git",
+          "type": "git",
+          "tag": "2.6.6",
+          "commit": "f9e868388ce7740ce27409f8629da3e9666cc04f"
         }
       ]
     },

--- a/io.github.diegoivan.pdf_metadata_editor.json
+++ b/io.github.diegoivan.pdf_metadata_editor.json
@@ -1,7 +1,7 @@
 {
   "app-id": "io.github.diegoivan.pdf_metadata_editor",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "48",
+  "runtime-version": "49",
   "sdk": "org.gnome.Sdk",
   "command": "pdf-metadata-editor",
   "finish-args": [


### PR DESCRIPTION
- Update runtime to 49
- Update poppler version to 25.12.0
- Update exempi version to 2.6.6
- Add a basic README.md
- A few more cleanup commands to reduce the flatpak size