### PR TITLE
Update runtime to 50

### DIFF
--- a/io.github.diegoivan.pdf_metadata_editor.json
+++ b/io.github.diegoivan.pdf_metadata_editor.json
@@ -1,7 +1,7 @@
 {
   "app-id": "io.github.diegoivan.pdf_metadata_editor",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "48",
+  "runtime-version": "50",
   "sdk": "org.gnome.Sdk",
   "command": "pdf-metadata-editor",
   "finish-args": [
@@ -12,9 +12,11 @@
   ],
   "cleanup": [
     "/include",
+    "/lib/girepository-1.0",
     "/lib/pkgconfig",
     "/man",
     "/share/doc",
+    "/share/gir-1.0",
     "/share/gtk-doc",
     "/share/man",
     "/share/pkgconfig",
@@ -44,10 +46,9 @@
       ],
       "sources": [
         {
-          "url": "https://gitlab.freedesktop.org/poppler/poppler.git",
-          "type": "git",
-          "tag": "poppler-23.01.0",
-          "commit": "4259ff0c2067d302f97d87221a442eec8e88d45c"
+          "type": "archive",
+          "url": "https://poppler.freedesktop.org/poppler-26.02.0.tar.xz",
+          "sha256": "dded8621f7b2f695c91063aab1558691c8418374cd583501e89ed39487e7ab77"
         }
       ]
     },
@@ -60,9 +61,9 @@
       ],
       "sources": [
         {
-          "url": "https://gitlab.freedesktop.org/libopenraw/exempi/-/archive/2.6.4/exempi-2.6.4.tar.gz",
           "type": "archive",
-          "sha256": "7d1b0e96b848fe3fcf5f5bdb353cc82527b6629e40ed838efe9ffc9108e1b99b"
+          "url": "https://libopenraw.freedesktop.org/download/exempi-2.6.6.tar.xz",
+          "sha256": "900fb9957be2095c78e5111b99c49378adac58161a358f52f93c55126f34eb8f"
         }
       ]
     },


### PR DESCRIPTION
- Update runtime to 50
- Update poppler version
- Update exempi version
- Improve cleanup commands to reduce the flatpak size